### PR TITLE
removed crd name override

### DIFF
--- a/apis/cosi.sigs.k8s.io/v1alpha1/openapi_generated.go
+++ b/apis/cosi.sigs.k8s.io/v1alpha1/openapi_generated.go
@@ -193,7 +193,6 @@ func schema_api_apis_cosisigsk8sio_v1alpha1_BucketAccess(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"status"},
 			},
 		},
 		Dependencies: []string{
@@ -405,7 +404,6 @@ func schema_api_apis_cosisigsk8sio_v1alpha1_BucketAccessRequest(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"status"},
 			},
 		},
 		Dependencies: []string{

--- a/apis/cosi.sigs.k8s.io/v1alpha1/types.go
+++ b/apis/cosi.sigs.k8s.io/v1alpha1/types.go
@@ -77,16 +77,17 @@ const (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Namespaced,path=bucketRequests
+// +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:resource:path=bucket-request
 
 type BucketRequest struct {
 	metav1.TypeMeta   `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   BucketRequestSpec   `json:"spec,omitempty"`
+	// +optional
 	Status BucketRequestStatus `json:"status,omitempty"`
 }
 
@@ -101,16 +102,17 @@ type BucketRequestList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Cluster,path=buckets
+// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=bucket
 
 type Bucket struct {
 	metav1.TypeMeta   `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   BucketSpec   `json:"spec,omitempty"`
+	// +optional
 	Status BucketStatus `json:"status,omitempty"`
 }
 
@@ -125,12 +127,12 @@ type BucketList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Cluster,path=bucketClasses
+// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:storageversion
-// +kubebuilder:resource:path=bucket-class
 
 type BucketClass struct {
 	metav1.TypeMeta   `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Provisioner string `json:"provisioner,omitempty"`
@@ -170,12 +172,12 @@ type PolicyActions struct {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Cluster,path=bucketAccessClasses
+// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:storageversion
-// +kubebuilder:resource:path=bucket-access-class
 
 type BucketAccessClass struct {
 	metav1.TypeMeta   `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Provisioner   string        `json:"provisioner,omitempty"`
@@ -219,16 +221,17 @@ type BucketAccessStatus struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Cluster,path=bucketAccesses
+// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=bucket-access
 
 type BucketAccess struct {
 	metav1.TypeMeta   `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec BucketAccessSpec `json:"spec,omitempty"`
+	// +optional
 	Status BucketAccessStatus `json:"status"`
 }
 
@@ -261,16 +264,17 @@ type BucketAccessRequestStatus struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Namespaced,path=bucketAccessRequests
+// +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=bucket-access-request
 
 type BucketAccessRequest struct {
 	metav1.TypeMeta   `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec BucketAccessRequestSpec `json:"spec,omitempty"`
+	// +optional
 	Status BucketAccessRequestStatus `json:"status"`
 }
 

--- a/config/crd/cosi.sigs.k8s.io_bucketaccessclasses.yaml
+++ b/config/crd/cosi.sigs.k8s.io_bucketaccessclasses.yaml
@@ -7,15 +7,15 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
     api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1383
   creationTimestamp: null
-  name: bucket-access-class.cosi.sigs.k8s.io
+  name: bucketaccessclasses.cosi.sigs.k8s.io
 spec:
   group: cosi.sigs.k8s.io
   names:
     kind: BucketAccessClass
     listKind: BucketAccessClassList
-    plural: bucket-access-class
+    plural: bucketaccessclasses
     singular: bucketaccessclass
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/config/crd/cosi.sigs.k8s.io_bucketaccesses.yaml
+++ b/config/crd/cosi.sigs.k8s.io_bucketaccesses.yaml
@@ -7,51 +7,25 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
     api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1383
   creationTimestamp: null
-  name: bucket-class.cosi.sigs.k8s.io
+  name: bucketaccesses.cosi.sigs.k8s.io
 spec:
   group: cosi.sigs.k8s.io
   names:
-    kind: BucketClass
-    listKind: BucketClassList
-    plural: bucket-class
-    singular: bucketclass
-  scope: Namespaced
+    kind: BucketAccess
+    listKind: BucketAccessList
+    plural: bucketaccesses
+    singular: bucketaccess
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
-          additionalPermittedNamespaces:
-            items:
-              properties:
-                name:
-                  type: string
-                uid:
-                  type: string
-              required:
-              - name
-              - uid
-              type: object
-            type: array
-          anonymousAccessModes:
-            items:
-              properties:
-                private:
-                  type: boolean
-                publicReadOnly:
-                  type: boolean
-                publicReadWrite:
-                  type: boolean
-              type: object
-            type: array
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
-          isDefaultBucketClass:
-            default: false
-            type: boolean
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -59,24 +33,35 @@ spec:
             type: string
           metadata:
             type: object
-          parameters:
-            additionalProperties:
-              type: string
+          spec:
+            properties:
+              bucketAccessRequestName:
+                type: string
+              bucketAccessRequestNamespace:
+                type: string
+              keySecretName:
+                type: string
+              parameters:
+                additionalProperties:
+                  type: string
+                type: object
+              provisioner:
+                type: string
+              serviceAccountName:
+                type: string
             type: object
-          provisioner:
-            type: string
-          releasePolicy:
-            default: retain
-            type: string
-          supportedProtocols:
-            items:
-              type: string
-            type: array
-        required:
-        - supportedProtocols
+          status:
+            properties:
+              message:
+                type: string
+              phase:
+                type: string
+            type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/cosi.sigs.k8s.io_bucketaccessrequests.yaml
+++ b/config/crd/cosi.sigs.k8s.io_bucketaccessrequests.yaml
@@ -7,14 +7,14 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
     api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1383
   creationTimestamp: null
-  name: bucket-request.cosi.sigs.k8s.io
+  name: bucketaccessrequests.cosi.sigs.k8s.io
 spec:
   group: cosi.sigs.k8s.io
   names:
-    kind: BucketRequest
-    listKind: BucketRequestList
-    plural: bucket-request
-    singular: bucketrequest
+    kind: BucketAccessRequest
+    listKind: BucketAccessRequestList
+    plural: bucketaccessrequests
+    singular: bucketaccessrequest
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -35,21 +35,21 @@ spec:
             type: object
           spec:
             properties:
-              bucketClassName:
+              accessSecretName:
                 type: string
-              bucketName:
+              bucketAccessClassName:
                 type: string
-              bucketPrefix:
+              bucketAccessName:
                 type: string
-              protocol:
+              bucketRequestName:
                 type: string
-              secretName:
+              serviceAccountName:
                 type: string
-            required:
-            - protocol
             type: object
           status:
             properties:
+              message:
+                type: string
               phase:
                 type: string
             type: object

--- a/config/crd/cosi.sigs.k8s.io_bucketclasses.yaml
+++ b/config/crd/cosi.sigs.k8s.io_bucketclasses.yaml
@@ -7,25 +7,51 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
     api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1383
   creationTimestamp: null
-  name: bucket-access-request.cosi.sigs.k8s.io
+  name: bucketclasses.cosi.sigs.k8s.io
 spec:
   group: cosi.sigs.k8s.io
   names:
-    kind: BucketAccessRequest
-    listKind: BucketAccessRequestList
-    plural: bucket-access-request
-    singular: bucketaccessrequest
-  scope: Namespaced
+    kind: BucketClass
+    listKind: BucketClassList
+    plural: bucketclasses
+    singular: bucketclass
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
+          additionalPermittedNamespaces:
+            items:
+              properties:
+                name:
+                  type: string
+                uid:
+                  type: string
+              required:
+              - name
+              - uid
+              type: object
+            type: array
+          anonymousAccessModes:
+            items:
+              properties:
+                private:
+                  type: boolean
+                publicReadOnly:
+                  type: boolean
+                publicReadWrite:
+                  type: boolean
+              type: object
+            type: array
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
+          isDefaultBucketClass:
+            default: false
+            type: boolean
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -33,33 +59,24 @@ spec:
             type: string
           metadata:
             type: object
-          spec:
-            properties:
-              accessSecretName:
-                type: string
-              bucketAccessClassName:
-                type: string
-              bucketAccessName:
-                type: string
-              bucketRequestName:
-                type: string
-              serviceAccountName:
-                type: string
+          parameters:
+            additionalProperties:
+              type: string
             type: object
-          status:
-            properties:
-              message:
-                type: string
-              phase:
-                type: string
-            type: object
+          provisioner:
+            type: string
+          releasePolicy:
+            default: retain
+            type: string
+          supportedProtocols:
+            items:
+              type: string
+            type: array
         required:
-        - status
+        - supportedProtocols
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/cosi.sigs.k8s.io_bucketrequests.yaml
+++ b/config/crd/cosi.sigs.k8s.io_bucketrequests.yaml
@@ -7,14 +7,14 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
     api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1383
   creationTimestamp: null
-  name: bucket-access.cosi.sigs.k8s.io
+  name: bucketrequests.cosi.sigs.k8s.io
 spec:
   group: cosi.sigs.k8s.io
   names:
-    kind: BucketAccess
-    listKind: BucketAccessList
-    plural: bucket-access
-    singular: bucketaccess
+    kind: BucketRequest
+    listKind: BucketRequestList
+    plural: bucketrequests
+    singular: bucketrequest
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -35,30 +35,24 @@ spec:
             type: object
           spec:
             properties:
-              bucketAccessRequestName:
+              bucketClassName:
                 type: string
-              bucketAccessRequestNamespace:
+              bucketName:
                 type: string
-              keySecretName:
+              bucketPrefix:
                 type: string
-              parameters:
-                additionalProperties:
-                  type: string
-                type: object
-              provisioner:
+              protocol:
                 type: string
-              serviceAccountName:
+              secretName:
                 type: string
+            required:
+            - protocol
             type: object
           status:
             properties:
-              message:
-                type: string
               phase:
                 type: string
             type: object
-        required:
-        - status
         type: object
     served: true
     storage: true

--- a/config/crd/cosi.sigs.k8s.io_buckets.yaml
+++ b/config/crd/cosi.sigs.k8s.io_buckets.yaml
@@ -7,15 +7,15 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
     api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1383
   creationTimestamp: null
-  name: bucket.cosi.sigs.k8s.io
+  name: buckets.cosi.sigs.k8s.io
 spec:
   group: cosi.sigs.k8s.io
   names:
     kind: Bucket
     listKind: BucketList
-    plural: bucket
+    plural: buckets
     singular: bucket
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:


### PR DESCRIPTION
Removes the `path=...` options from kubebuilder tags to allow default naming of crds to occur.